### PR TITLE
feat: improve Logger interface

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ kind: pipeline
 name: commitlint
 steps:
   - name: npm install
-    image: &node_image node:10.14.1-alpine
+    image: &node_image node:10.15.1-alpine
     commands:
       - npm i
   - name: tag/commitlint
@@ -39,15 +39,15 @@ steps:
   - name: go vet
     # exec: "gcc": executable file not found in $PATH
     # gcc is required
-    image: golang:1.11.2
+    image: &image_go golang:1.11.5
     commands:
       - go vet ./...
   - name: gometalinter
-    image: suzukishunsuke/go-ci:1.0.0
+    image: suzukishunsuke/go-ci:1.1.0
     commands:
       - gometalinter ./...
   - name: go test
-    image: golang:1.11.2
+    image: *image_go
     commands:
       # gcc seems to be required
       # runtime/cgo
@@ -57,7 +57,7 @@ steps:
       event:
         - pull_request
   - name: codecov
-    image: golang:1.11.2
+    image: *image_go
     commands:
       # bash and cgo seem to be required
       - bash scripts/codecov-test.sh

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -14,7 +14,7 @@
     "varcheck",
     "structcheck",
     "goconst",
-    "megacheck"
+    "staticcheck"
   ],
   "Vendor": true,
   "Deadline": "300s"

--- a/examples/example1.go
+++ b/examples/example1.go
@@ -10,19 +10,19 @@ import (
 
 func foo() (int, error) {
 	age, err := getAge("foo")
-	return age, errlog.Wrap(err, nil, "failed to foo")
+	return age, errlog.Wrap(err, logrus.Fields{
+		"name": "foo",
+	}, "failed to get age")
 }
 
 func getAge(name string) (int, error) {
-	return 0, errlog.New(logrus.Fields{
-		"name": name,
-	}, "invalid name", "failed to get an age")
+	return 0, fmt.Errorf("invalid name")
 }
 
 func main() {
 	logger := errlog.NewLogger(nil).
-		WithFields(logrus.Fields{"program": "example1"})
+		With(logrus.Fields{"program": "example1"}, "example is failure")
 	age, err := foo()
-	logger.Fatal(err) // you don't have to check err is nil or not.
+	logger.Fatal(err, nil, "function foo is failure") // you don't have to check err is nil or not.
 	fmt.Printf("age: %d\n", age)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -19,57 +19,107 @@ func TestNewLogger(t *testing.T) {
 	require.NotNil(t, logger.logger)
 }
 
-func TestLoggerWithField(t *testing.T) {
+func TestLoggerWith(t *testing.T) {
 	logger := NewLogger(nil)
-	logger = logger.WithField("foo", "bar")
-	logger.Info(fmt.Errorf("hello"))
+	logger = logger.With(logrus.Fields{"foo": "bar"}, "hello world")
+	logger.Info(fmt.Errorf("hello"), nil)
 }
 
-func TestLoggerWithFields(t *testing.T) {
+func TestLoggerWithf(t *testing.T) {
 	logger := NewLogger(nil)
-	logger = logger.WithFields(logrus.Fields{"foo": "bar"})
-	logger.Info(fmt.Errorf("hello"))
+	logger = logger.Withf(logrus.Fields{"foo": "bar"}, "hello %s", "bob")
+	logger.Info(fmt.Errorf("hello"), nil)
+}
+
+func TestLogger_debug(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.debug(nil)
+	logger.debug(fmt.Errorf("hello"))
+	logger.debug(New(nil, "bar"))
+	var e *Error
+	logger.debug(e)
 }
 
 func TestLoggerDebug(t *testing.T) {
 	logger := NewLogger(nil)
-	logger.Debug(nil)
-	logger.Debug(fmt.Errorf("hello"))
-	logger.Debug(New(nil, "bar"))
+	logger.Debug(fmt.Errorf("invalid user name"), nil)
+}
+
+func TestLoggerDebugf(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.Debugf(fmt.Errorf("invalid user name"), nil, "hello %s", "bob")
+}
+
+func TestLogger_err(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.err(nil)
+	logger.err(fmt.Errorf("hello"))
+	logger.err(New(nil, "bar"))
 	var e *Error
-	logger.Debug(e)
+	logger.err(e)
 }
 
 func TestLoggerError(t *testing.T) {
 	logger := NewLogger(nil)
-	logger.Error(nil)
-	logger.Error(fmt.Errorf("hello"))
-	logger.Error(New(nil, "bar"))
+	logger.Error(fmt.Errorf("invalid user name"), nil)
+}
+
+func TestLoggerErrorf(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.Errorf(fmt.Errorf("invalid user name"), nil, "hello %s", "bob")
+}
+
+func TestLogger_fatal(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.fatal(nil)
 	var e *Error
-	logger.Error(e)
+	logger.fatal(e)
 }
 
 func TestLoggerFatal(t *testing.T) {
 	logger := NewLogger(nil)
-	logger.Fatal(nil)
+	logger.Fatal(nil, nil)
+}
+
+func TestLoggerFatalf(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.Fatalf(nil, nil, "hello %s", "bob")
+}
+
+func TestLogger_info(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.info(nil)
+	logger.info(fmt.Errorf("hello"))
+	logger.info(New(nil, "bar"))
 	var e *Error
-	logger.Fatal(e)
+	logger.info(e)
 }
 
 func TestLoggerInfo(t *testing.T) {
 	logger := NewLogger(nil)
-	logger.Info(nil)
-	logger.Info(fmt.Errorf("hello"))
-	logger.Info(New(nil, "bar"))
+	logger.Info(fmt.Errorf("invalid user name"), nil)
+}
+
+func TestLoggerInfof(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.Infof(fmt.Errorf("invalid user name"), nil, "hello %s", "bob")
+}
+
+func TestLogger_warn(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.warn(nil)
+	logger.warn(fmt.Errorf("hello"))
+	logger.warn(New(nil, "bar"))
 	var e *Error
-	logger.Info(e)
+	logger.warn(e)
 }
 
 func TestLoggerWarn(t *testing.T) {
 	logger := NewLogger(nil)
-	logger.Warn(nil)
-	logger.Warn(fmt.Errorf("hello"))
-	logger.Warn(New(nil, "bar"))
-	var e *Error
-	logger.Warn(e)
+	logger.Warn(fmt.Errorf("invalid user name"), nil)
+}
+
+func TestLoggerWarnf(t *testing.T) {
+	logger := NewLogger(nil)
+	logger.Warnf(fmt.Errorf("invalid user name"), nil, "hello %s", "bob")
 }


### PR DESCRIPTION
Close #8 

* add msgs fields to Logger
* add Logger.With and Logger.Withf method
* add Logger.xxxf methods (Debugf, Infof, Fatalf, Warnf, Errorf)
* add fields and msgs arguments to Logger's logging method (Debug, Info, Fatal, Warn, Error)

BREAKING CHANGE:

* remove logger.WithFields and logger.WithField methods
* fields argument is required for Logger's logging method (Debug, Info, Fatal, Warn, Error)

## How to migrate

Replace logger.WithFields and logger.WithField to logger.With or logger.Withf .

```go
// before
logger.WithFields(logrus.Fields{"foo": "bar"})

// after
logger.With(logrus.Fields{"foo": "bar"})
```

Add nil or logrus.Fields to Logger's logging method's argument

```go
// before
logger.Error(err)

// after
logger.Error(err, nil)
```

```go
// before
logger.Error(errlog.Wrap(err, logrus.Fields{"foo": "bar"}, "hello world"))

// after
logger.Error(err, logrus.Fields{"foo": "bar"}, "hello world")
```

---

ci: update Docker images

---

ci: replace megacheck to staticcheck

alecthomas/gometalinter#579

megacheck has been subsumed by staticcheck.