### PR TITLE
remove some APIs and fix the Cause method and improve tests

### DIFF
--- a/errlog.go
+++ b/errlog.go
@@ -13,7 +13,14 @@ func CheckField(err error, key string, f func(v interface{}) bool) bool {
 		return false
 	}
 	if e, ok := err.(*Error); ok {
-		return e.CheckField(key, f)
+		if e == nil {
+			return false
+		}
+		v, ok := e.Fields()[key]
+		if ok {
+			return f(v)
+		}
+		return false
 	}
 	return false
 }
@@ -26,7 +33,11 @@ func GetField(err error, key string) (interface{}, bool) {
 		return nil, false
 	}
 	if e, ok := err.(*Error); ok {
-		return e.GetField(key)
+		if e == nil {
+			return nil, false
+		}
+		v, ok := e.Fields()[key]
+		return v, ok
 	}
 	return nil, false
 }
@@ -37,7 +48,11 @@ func HasField(err error, key string) bool {
 		return false
 	}
 	if e, ok := err.(*Error); ok {
-		return e.HasField(key)
+		if e == nil {
+			return false
+		}
+		_, ok := e.Fields()[key]
+		return ok
 	}
 	return false
 }
@@ -50,7 +65,15 @@ func HasMsg(err error, msg string) bool {
 		return false
 	}
 	if e, ok := err.(*Error); ok {
-		return e.HasMsg(msg)
+		if e == nil {
+			return false
+		}
+		for _, m := range e.Msgs() {
+			if m == msg {
+				return true
+			}
+		}
+		return false
 	}
 	return err.Error() == msg
 }

--- a/errlog.go
+++ b/errlog.go
@@ -12,7 +12,7 @@ func CheckField(err error, key string, f func(v interface{}) bool) bool {
 	if err == nil {
 		return false
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return false
 		}
@@ -32,7 +32,7 @@ func GetField(err error, key string) (interface{}, bool) {
 	if err == nil {
 		return nil, false
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return nil, false
 		}
@@ -47,7 +47,7 @@ func HasField(err error, key string) bool {
 	if err == nil {
 		return false
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return false
 		}
@@ -59,12 +59,12 @@ func HasField(err error, key string) bool {
 
 // HasMsg returns whether error has the message.
 // If err is nil, returns false.
-// If err isn't Error, returns err.Error() == msg .
+// If err isn't base, returns err.Error() == msg .
 func HasMsg(err error, msg string) bool {
 	if err == nil {
 		return false
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return false
 		}
@@ -80,14 +80,14 @@ func HasMsg(err error, msg string) bool {
 
 // New is a shorthand of combination of Wrap and fmt.Errorf .
 func New(fields logrus.Fields, msg string, msgs ...string) error {
-	return &Error{
+	return &base{
 		err: fmt.Errorf(msg), msgs: append([]string{msg}, msgs...), fields: fields}
 }
 
 // Newf is a shorthand of combination of New and fmt.Sprintf .
 func Newf(fields logrus.Fields, msg string, a ...interface{}) error {
 	s := fmt.Sprintf(msg, a...)
-	return &Error{err: fmt.Errorf(s), msgs: []string{s}, fields: fields}
+	return &base{err: fmt.Errorf(s), msgs: []string{s}, fields: fields}
 }
 
 // Wrap returns an error added fields and msgs.
@@ -96,11 +96,11 @@ func Wrap(err error, fields logrus.Fields, msgs ...string) error {
 	if err == nil {
 		return nil
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return nil
 		}
-		ret := &Error{
+		ret := &base{
 			err:    e.err,
 			msgs:   append(e.msgs, msgs...),
 			fields: e.fields,
@@ -113,7 +113,7 @@ func Wrap(err error, fields logrus.Fields, msgs ...string) error {
 		}
 		return ret
 	}
-	return &Error{
+	return &base{
 		err: err, msgs: append([]string{err.Error()}, msgs...), fields: fields}
 }
 

--- a/errlog.go
+++ b/errlog.go
@@ -16,7 +16,7 @@ func CheckField(err error, key string, f func(v interface{}) bool) bool {
 		if e == nil {
 			return false
 		}
-		v, ok := e.Fields()[key]
+		v, ok := e.fields[key]
 		if ok {
 			return f(v)
 		}
@@ -36,7 +36,7 @@ func GetField(err error, key string) (interface{}, bool) {
 		if e == nil {
 			return nil, false
 		}
-		v, ok := e.Fields()[key]
+		v, ok := e.fields[key]
 		return v, ok
 	}
 	return nil, false
@@ -51,7 +51,7 @@ func HasField(err error, key string) bool {
 		if e == nil {
 			return false
 		}
-		_, ok := e.Fields()[key]
+		_, ok := e.fields[key]
 		return ok
 	}
 	return false
@@ -68,7 +68,7 @@ func HasMsg(err error, msg string) bool {
 		if e == nil {
 			return false
 		}
-		for _, m := range e.Msgs() {
+		for _, m := range e.msgs {
 			if m == msg {
 				return true
 			}

--- a/errlog_test.go
+++ b/errlog_test.go
@@ -12,7 +12,7 @@ func TestCheckField(t *testing.T) {
 	f := func(v interface{}) bool {
 		return v == 1
 	}
-	var e *Error
+	var e *base
 	data := []struct {
 		title string
 		err   error
@@ -22,24 +22,24 @@ func TestCheckField(t *testing.T) {
 			title: "err is nil",
 		},
 		{
-			title: "Error is nil",
+			title: "base is nil",
 			err:   e,
 		},
 		{
-			title: "not Error",
+			title: "not base",
 			err:   fmt.Errorf("foo"),
 		},
 		{
-			title: "Error doesn't have the key",
-			err:   &Error{},
+			title: "base doesn't have the key",
+			err:   &base{},
 		},
 		{
 			title: "the function returns false",
-			err:   &Error{fields: logrus.Fields{"foo": 0}},
+			err:   &base{fields: logrus.Fields{"foo": 0}},
 		},
 		{
 			title: "the function returns true",
-			err:   &Error{fields: logrus.Fields{"foo": 1}},
+			err:   &base{fields: logrus.Fields{"foo": 1}},
 			exp:   true,
 		},
 	}
@@ -55,7 +55,7 @@ func TestCheckField(t *testing.T) {
 }
 
 func TestGetField(t *testing.T) {
-	var e *Error
+	var e *base
 	data := []struct {
 		title string
 		err   error
@@ -70,12 +70,12 @@ func TestGetField(t *testing.T) {
 			err:   fmt.Errorf("foo"),
 		},
 		{
-			title: "err is an Error but nil",
+			title: "err is a base but nil",
 			err:   e,
 		},
 		{
-			title: "err is an Error",
-			err:   &Error{fields: logrus.Fields{"foo": "bar"}},
+			title: "err is a base",
+			err:   &base{fields: logrus.Fields{"foo": "bar"}},
 			expV:  "bar",
 			expB:  true,
 		},
@@ -94,7 +94,7 @@ func TestGetField(t *testing.T) {
 }
 
 func TestHasField(t *testing.T) {
-	var e *Error
+	var e *base
 	data := []struct {
 		title string
 		err   error
@@ -104,21 +104,21 @@ func TestHasField(t *testing.T) {
 			title: "err is nil",
 		},
 		{
-			title: "err is not Error",
+			title: "err is not base",
 			err:   fmt.Errorf("foo"),
 		},
 		{
-			title: "err is an Error but nil",
+			title: "err is a base but nil",
 			err:   e,
 		},
 		{
-			title: "err is an Error",
-			err:   &Error{fields: logrus.Fields{"foo": "bar"}},
+			title: "err is an base",
+			err:   &base{fields: logrus.Fields{"foo": "bar"}},
 			exp:   true,
 		},
 		{
-			title: "err is an Error but doesn't have the field",
-			err:   &Error{},
+			title: "err is a base but doesn't have the field",
+			err:   &base{},
 			exp:   false,
 		},
 	}
@@ -134,7 +134,7 @@ func TestHasField(t *testing.T) {
 }
 
 func TestHasMsg(t *testing.T) {
-	var e *Error
+	var e *base
 	data := []struct {
 		title string
 		err   error
@@ -144,25 +144,25 @@ func TestHasMsg(t *testing.T) {
 			title: "err is nil",
 		},
 		{
-			title: "err isn't an Error but has the message",
+			title: "err isn't a base but has the message",
 			err:   fmt.Errorf("foo"),
 			exp:   true,
 		},
 		{
-			title: "err isn't Error",
+			title: "err isn't base",
 			err:   fmt.Errorf("bar"),
 		},
 		{
-			title: "err is an Error but nil",
+			title: "err is a base but nil",
 			err:   e,
 		},
 		{
-			title: "err is an Error but doesn't have the message",
-			err:   &Error{},
+			title: "err is a base but doesn't have the message",
+			err:   &base{},
 		},
 		{
-			title: "err is an Error and has the message",
-			err:   &Error{msgs: []string{"foo"}},
+			title: "err is a base and has the message",
+			err:   &base{msgs: []string{"foo"}},
 			exp:   true,
 		},
 	}
@@ -178,25 +178,25 @@ func TestHasMsg(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	require.Equal(t, &Error{err: fmt.Errorf("foo"), msgs: []string{"foo"}}, New(nil, "foo"))
+	require.Equal(t, &base{err: fmt.Errorf("foo"), msgs: []string{"foo"}}, New(nil, "foo"))
 	require.Equal(
-		t, &Error{err: fmt.Errorf("foo"), msgs: []string{"foo", "bar"}, fields: logrus.Fields{"program": "main"}},
+		t, &base{err: fmt.Errorf("foo"), msgs: []string{"foo", "bar"}, fields: logrus.Fields{"program": "main"}},
 		New(logrus.Fields{"program": "main"}, "foo", "bar"))
 }
 
 func TestNewf(t *testing.T) {
 	require.Equal(
-		t, &Error{err: fmt.Errorf("foo bar"), msgs: []string{"foo bar"}},
+		t, &base{err: fmt.Errorf("foo bar"), msgs: []string{"foo bar"}},
 		Newf(nil, "foo %s", "bar"))
 	require.Equal(
-		t, &Error{
+		t, &base{
 			err: fmt.Errorf("foo"), msgs: []string{"foo"},
 			fields: logrus.Fields{"program": "main"}},
 		Newf(logrus.Fields{"program": "main"}, "foo"))
 }
 
 func TestWrap(t *testing.T) {
-	var e *Error
+	var e *base
 	data := []struct {
 		title  string
 		err    error
@@ -206,16 +206,16 @@ func TestWrap(t *testing.T) {
 	}{{
 		title: "err is nil",
 	}, {
-		title: "err is Error but nil",
+		title: "err is base but nil",
 		err:   e,
 	}, {
-		title: "err is not Error",
+		title: "err is not base",
 		err:   fmt.Errorf("foo"),
 		msgs:  []string{"bar"},
 		fields: logrus.Fields{
 			"foo": "bar",
 		},
-		exp: &Error{
+		exp: &base{
 			err:  fmt.Errorf("foo"),
 			msgs: []string{"foo", "bar"},
 			fields: logrus.Fields{
@@ -223,8 +223,8 @@ func TestWrap(t *testing.T) {
 			},
 		},
 	}, {
-		title: "err is an Error",
-		err: &Error{
+		title: "err is a base",
+		err: &base{
 			err: fmt.Errorf("foo"),
 			fields: logrus.Fields{
 				"foo": "bar",
@@ -236,7 +236,7 @@ func TestWrap(t *testing.T) {
 			"foo": "goo",
 		},
 		msgs: []string{"zoo"},
-		exp: &Error{
+		exp: &base{
 			err:  fmt.Errorf("foo"),
 			msgs: []string{"foo", "zoo"},
 			fields: logrus.Fields{

--- a/errlog_test.go
+++ b/errlog_test.go
@@ -9,43 +9,172 @@ import (
 )
 
 func TestCheckField(t *testing.T) {
-	require.False(t, CheckField(nil, "foo", func(v interface{}) bool {
+	f := func(v interface{}) bool {
 		return v == 1
-	}))
+	}
 	var e *Error
-	require.False(t, CheckField(e, "foo", func(v interface{}) bool {
-		return v == 1
-	}))
-	require.False(t, CheckField(fmt.Errorf("foo"), "foo", func(v interface{}) bool {
-		return v == 1
-	}))
+	data := []struct {
+		title string
+		err   error
+		exp   bool
+	}{
+		{
+			title: "err is nil",
+		},
+		{
+			title: "Error is nil",
+			err:   e,
+		},
+		{
+			title: "not Error",
+			err:   fmt.Errorf("foo"),
+		},
+		{
+			title: "Error doesn't have the key",
+			err:   &Error{},
+		},
+		{
+			title: "the function returns false",
+			err:   &Error{fields: logrus.Fields{"foo": 0}},
+		},
+		{
+			title: "the function returns true",
+			err:   &Error{fields: logrus.Fields{"foo": 1}},
+			exp:   true,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.title, func(t *testing.T) {
+			if d.exp {
+				require.True(t, CheckField(d.err, "foo", f))
+				return
+			}
+			require.False(t, CheckField(d.err, "foo", f))
+		})
+	}
 }
 
 func TestGetField(t *testing.T) {
-	_, ok := GetField(nil, "foo")
-	require.False(t, ok)
-	_, ok = GetField(fmt.Errorf("foo"), "foo")
-	require.False(t, ok)
 	var e *Error
-	_, ok = GetField(e, "foo")
-	require.False(t, ok)
-	v, ok := GetField(&Error{fields: logrus.Fields{"foo": "bar"}}, "foo")
-	require.True(t, ok)
-	require.Equal(t, "bar", v)
+	data := []struct {
+		title string
+		err   error
+		expV  interface{}
+		expB  bool
+	}{
+		{
+			title: "err is nil",
+		},
+		{
+			title: "err is a normal error",
+			err:   fmt.Errorf("foo"),
+		},
+		{
+			title: "err is an Error but nil",
+			err:   e,
+		},
+		{
+			title: "err is an Error",
+			err:   &Error{fields: logrus.Fields{"foo": "bar"}},
+			expV:  "bar",
+			expB:  true,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.title, func(t *testing.T) {
+			v, ok := GetField(d.err, "foo")
+			if !d.expB {
+				require.False(t, ok)
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, d.expV, v)
+		})
+	}
 }
 
 func TestHasField(t *testing.T) {
-	require.False(t, HasField(nil, "foo"))
-	require.False(t, HasField(fmt.Errorf("foo"), "foo"))
 	var e *Error
-	require.False(t, HasField(e, "foo"))
+	data := []struct {
+		title string
+		err   error
+		exp   bool
+	}{
+		{
+			title: "err is nil",
+		},
+		{
+			title: "err is not Error",
+			err:   fmt.Errorf("foo"),
+		},
+		{
+			title: "err is an Error but nil",
+			err:   e,
+		},
+		{
+			title: "err is an Error",
+			err:   &Error{fields: logrus.Fields{"foo": "bar"}},
+			exp:   true,
+		},
+		{
+			title: "err is an Error but doesn't have the field",
+			err:   &Error{},
+			exp:   false,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.title, func(t *testing.T) {
+			if d.exp {
+				require.True(t, HasField(d.err, "foo"))
+				return
+			}
+			require.False(t, HasField(d.err, "foo"))
+		})
+	}
 }
 
 func TestHasMsg(t *testing.T) {
-	require.False(t, HasMsg(nil, "foo"))
-	require.True(t, HasMsg(fmt.Errorf("foo"), "foo"))
 	var e *Error
-	require.False(t, HasMsg(e, "foo"))
+	data := []struct {
+		title string
+		err   error
+		exp   bool
+	}{
+		{
+			title: "err is nil",
+		},
+		{
+			title: "err isn't an Error but has the message",
+			err:   fmt.Errorf("foo"),
+			exp:   true,
+		},
+		{
+			title: "err isn't Error",
+			err:   fmt.Errorf("bar"),
+		},
+		{
+			title: "err is an Error but nil",
+			err:   e,
+		},
+		{
+			title: "err is an Error but doesn't have the message",
+			err:   &Error{},
+		},
+		{
+			title: "err is an Error and has the message",
+			err:   &Error{msgs: []string{"foo"}},
+			exp:   true,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.title, func(t *testing.T) {
+			if d.exp {
+				require.True(t, HasMsg(d.err, "foo"))
+				return
+			}
+			require.False(t, HasMsg(d.err, "foo"))
+		})
+	}
 }
 
 func TestNew(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -41,25 +41,3 @@ func (e *Error) Error() string {
 	}
 	return join(e.msgs...)
 }
-
-// Fields returns structured data of error.
-func (e *Error) Fields() logrus.Fields {
-	if e == nil {
-		return logrus.Fields{}
-	}
-	if e.fields == nil {
-		e.fields = logrus.Fields{}
-	}
-	return e.fields
-}
-
-// Msgs returns messages.
-func (e *Error) Msgs() []string {
-	if e == nil {
-		return []string{}
-	}
-	if e.msgs == nil {
-		e.msgs = []string{}
-	}
-	return e.msgs
-}

--- a/error.go
+++ b/error.go
@@ -13,12 +13,19 @@ type (
 		msgs   []string
 		fields logrus.Fields
 	}
+
+	causer interface {
+		Cause() error
+	}
 )
 
 // Cause returns a base error.
 func (e *Error) Cause() error {
 	if e == nil {
 		return nil
+	}
+	if err, ok := e.err.(causer); ok {
+		return err.Cause()
 	}
 	return e.err
 }

--- a/error.go
+++ b/error.go
@@ -7,8 +7,7 @@ import (
 )
 
 type (
-	// Error is a structured error.
-	Error struct {
+	base struct {
 		err    error
 		msgs   []string
 		fields logrus.Fields
@@ -20,7 +19,7 @@ type (
 )
 
 // Cause returns a base error.
-func (e *Error) Cause() error {
+func (e *base) Cause() error {
 	if e == nil {
 		return nil
 	}
@@ -35,7 +34,7 @@ func join(msgs ...string) string {
 }
 
 // Error returns a message represents error.
-func (e *Error) Error() string {
+func (e *base) Error() string {
 	if e == nil {
 		return ""
 	}

--- a/error.go
+++ b/error.go
@@ -23,18 +23,6 @@ func (e *Error) Cause() error {
 	return e.err
 }
 
-// CheckField checks the field's value.
-func (e *Error) CheckField(key string, f func(v interface{}) bool) bool {
-	if e == nil {
-		return false
-	}
-	v, ok := e.Fields()[key]
-	if ok {
-		return f(v)
-	}
-	return false
-}
-
 func join(msgs ...string) string {
 	return strings.Join(msgs, " : ")
 }
@@ -56,39 +44,6 @@ func (e *Error) Fields() logrus.Fields {
 		e.fields = logrus.Fields{}
 	}
 	return e.fields
-}
-
-// GetField returns the field value.
-// If error is nil or doesn't have the field,
-// nil and false are returned.
-func (e *Error) GetField(key string) (interface{}, bool) {
-	if e == nil {
-		return nil, false
-	}
-	v, ok := e.Fields()[key]
-	return v, ok
-}
-
-// HasField returns whether error has the field.
-func (e *Error) HasField(key string) bool {
-	if e == nil {
-		return false
-	}
-	_, ok := e.Fields()[key]
-	return ok
-}
-
-// HasMsg returns whether error has the message.
-func (e *Error) HasMsg(msg string) bool {
-	if e == nil {
-		return false
-	}
-	for _, m := range e.Msgs() {
-		if m == msg {
-			return true
-		}
-	}
-	return false
 }
 
 // Msgs returns messages.

--- a/error_test.go
+++ b/error_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestError_Cause(t *testing.T) {
-	msg := "foo"
-	err := Error{err: fmt.Errorf(msg)}
-	e := err.Cause()
-	require.NotNil(t, e)
-	require.Equal(t, msg, e.Error())
+	e := fmt.Errorf("foo")
+	err := Error{err: e}
+	require.Equal(t, e, err.Cause())
 	var e2 *Error
 	require.Nil(t, e2.Cause())
+	e3 := Error{err: &err}
+	require.Equal(t, e, e3.Cause())
 }
 
 func TestError_Error(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -7,21 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestError_Cause(t *testing.T) {
+func Test_base_Cause(t *testing.T) {
 	e := fmt.Errorf("foo")
-	err := Error{err: e}
+	err := base{err: e}
 	require.Equal(t, e, err.Cause())
-	var e2 *Error
+	var e2 *base
 	require.Nil(t, e2.Cause())
-	e3 := Error{err: &err}
+	e3 := base{err: &err}
 	require.Equal(t, e, e3.Cause())
 }
 
-func TestError_Error(t *testing.T) {
+func Test_base_Error(t *testing.T) {
 	err := Wrap(fmt.Errorf("foo"), nil)
 	require.Equal(t, "foo", err.Error())
 	e := Wrap(err, nil, "bar")
 	require.Equal(t, "foo : bar", e.Error())
-	var e2 *Error
+	var e2 *base
 	require.Equal(t, "", e2.Error())
 }

--- a/error_test.go
+++ b/error_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,31 +24,4 @@ func TestError_Error(t *testing.T) {
 	require.Equal(t, "foo : bar", e.Error())
 	var e2 *Error
 	require.Equal(t, "", e2.Error())
-}
-
-func TestError_Fields(t *testing.T) {
-	data := []struct {
-		fields logrus.Fields
-		exp    logrus.Fields
-	}{{
-		nil, logrus.Fields{},
-	}, {
-		logrus.Fields{"foo": "bar"}, logrus.Fields{"foo": "bar"},
-	}}
-	for _, d := range data {
-		err := Error{fields: d.fields}
-		require.Equal(t, d.exp, err.Fields())
-	}
-	var e2 *Error
-	require.Equal(t, logrus.Fields{}, e2.Fields())
-}
-
-func TestError_Msgs(t *testing.T) {
-	msgs := []string{"foo", "bar"}
-	err := &Error{err: fmt.Errorf("hello"), msgs: msgs}
-	require.Equal(t, msgs, err.Msgs())
-	err = nil
-	require.Equal(t, []string{}, err.Msgs())
-	err = &Error{err: fmt.Errorf("hello")}
-	require.Equal(t, []string{}, err.Msgs())
 }

--- a/error_test.go
+++ b/error_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrorCause(t *testing.T) {
+func TestError_Cause(t *testing.T) {
 	msg := "foo"
 	err := Error{err: fmt.Errorf(msg)}
 	e := err.Cause()
@@ -18,7 +18,7 @@ func TestErrorCause(t *testing.T) {
 	require.Nil(t, e2.Cause())
 }
 
-func TestErrorError(t *testing.T) {
+func TestError_Error(t *testing.T) {
 	err := Wrap(fmt.Errorf("foo"), nil)
 	require.Equal(t, "foo", err.Error())
 	e := Wrap(err, nil, "bar")
@@ -27,7 +27,7 @@ func TestErrorError(t *testing.T) {
 	require.Equal(t, "", e2.Error())
 }
 
-func TestErrorFields(t *testing.T) {
+func TestError_Fields(t *testing.T) {
 	data := []struct {
 		fields logrus.Fields
 		exp    logrus.Fields
@@ -44,7 +44,7 @@ func TestErrorFields(t *testing.T) {
 	require.Equal(t, logrus.Fields{}, e2.Fields())
 }
 
-func TestErrorMsgs(t *testing.T) {
+func TestError_Msgs(t *testing.T) {
 	msgs := []string{"foo", "bar"}
 	err := &Error{err: fmt.Errorf("hello"), msgs: msgs}
 	require.Equal(t, msgs, err.Msgs())

--- a/error_test.go
+++ b/error_test.go
@@ -18,16 +18,6 @@ func TestErrorCause(t *testing.T) {
 	require.Nil(t, e2.Cause())
 }
 
-func TestErrorCheckField(t *testing.T) {
-	err := Error{err: fmt.Errorf("foo"), fields: logrus.Fields{"bar": "zoo"}}
-	require.False(t, err.CheckField("foo", func(v interface{}) bool {
-		return v == 1
-	}))
-	require.True(t, err.CheckField("bar", func(v interface{}) bool {
-		return v == "zoo"
-	}))
-}
-
 func TestErrorError(t *testing.T) {
 	err := Wrap(fmt.Errorf("foo"), nil)
 	require.Equal(t, "foo", err.Error())
@@ -52,22 +42,6 @@ func TestErrorFields(t *testing.T) {
 	}
 	var e2 *Error
 	require.Equal(t, logrus.Fields{}, e2.Fields())
-}
-
-func TestErrorGetField(t *testing.T) {
-}
-
-func TestErrorHasField(t *testing.T) {
-	e := &Error{}
-	require.False(t, e.HasField("foo"))
-}
-
-func TestErrorHasMsg(t *testing.T) {
-	var e *Error
-	require.False(t, e.HasMsg("foo"))
-	e = &Error{msgs: []string{"foo"}}
-	require.True(t, e.HasMsg("foo"))
-	require.False(t, e.HasMsg("bar"))
 }
 
 func TestErrorMsgs(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -64,7 +64,7 @@ func (logger *Logger) debug(err error) {
 		if e == nil {
 			return
 		}
-		logger.logger.WithFields(e.Fields()).Debug(e)
+		logger.logger.WithFields(e.fields).Debug(e)
 	}
 	logger.logger.Debug(err)
 }
@@ -139,7 +139,7 @@ func (logger *Logger) err(err error) {
 		if e == nil {
 			return
 		}
-		logger.logger.WithFields(e.Fields()).Error(e)
+		logger.logger.WithFields(e.fields).Error(e)
 		return
 	}
 	logger.logger.Error(err)
@@ -165,7 +165,7 @@ func (logger *Logger) fatal(err error) {
 		if e == nil {
 			return
 		}
-		logger.logger.WithFields(e.Fields()).Fatal(e)
+		logger.logger.WithFields(e.fields).Fatal(e)
 	}
 	logger.logger.Fatal(err)
 }
@@ -190,7 +190,7 @@ func (logger *Logger) info(err error) {
 		if e == nil {
 			return
 		}
-		logger.logger.WithFields(e.Fields()).Info(e)
+		logger.logger.WithFields(e.fields).Info(e)
 		return
 	}
 	logger.logger.Info(err)
@@ -216,7 +216,7 @@ func (logger *Logger) warn(err error) {
 		if e == nil {
 			return
 		}
-		logger.logger.WithFields(e.Fields()).Warn(e)
+		logger.logger.WithFields(e.fields).Warn(e)
 		return
 	}
 	logger.logger.Warn(err)

--- a/logger.go
+++ b/logger.go
@@ -60,7 +60,7 @@ func (logger *Logger) debug(err error) {
 	if err == nil {
 		return
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return
 		}
@@ -135,7 +135,7 @@ func (logger *Logger) err(err error) {
 	if err == nil {
 		return
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return
 		}
@@ -161,7 +161,7 @@ func (logger *Logger) fatal(err error) {
 	if err == nil {
 		return
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return
 		}
@@ -186,7 +186,7 @@ func (logger *Logger) info(err error) {
 	if err == nil {
 		return
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return
 		}
@@ -212,7 +212,7 @@ func (logger *Logger) warn(err error) {
 	if err == nil {
 		return
 	}
-	if e, ok := err.(*Error); ok {
+	if e, ok := err.(*base); ok {
 		if e == nil {
 			return
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -19,19 +19,19 @@ func TestNewLogger(t *testing.T) {
 	require.NotNil(t, logger.logger)
 }
 
-func TestLoggerWithField(t *testing.T) {
+func TestLogger_WithField(t *testing.T) {
 	logger := NewLogger(nil)
 	logger = logger.WithField("foo", "bar")
 	logger.Info(fmt.Errorf("hello"))
 }
 
-func TestLoggerWithFields(t *testing.T) {
+func TestLogger_WithFields(t *testing.T) {
 	logger := NewLogger(nil)
 	logger = logger.WithFields(logrus.Fields{"foo": "bar"})
 	logger.Info(fmt.Errorf("hello"))
 }
 
-func TestLoggerLogger(t *testing.T) {
+func TestLogger_Logger(t *testing.T) {
 	logger := NewLogger(nil)
 	require.NotNil(t, logger.Logger())
 }
@@ -45,52 +45,52 @@ func TestLogger_debug(t *testing.T) {
 	logger.debug(e)
 }
 
-func TestLoggerSdebug(t *testing.T) {
+func TestLogger_Sdebug(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Sdebug("invalid user name")
 }
 
-func TestLoggerSdebugf(t *testing.T) {
+func TestLogger_Sdebugf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Sdebugf("hello %s", "bob")
 }
 
-func TestLoggerSwarn(t *testing.T) {
+func TestLogger_Swarn(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Swarn("invalid user name")
 }
 
-func TestLoggerSwarnf(t *testing.T) {
+func TestLogger_Swarnf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Swarnf("hello %s", "bob")
 }
 
-func TestLoggerSerror(t *testing.T) {
+func TestLogger_Serror(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Serror("invalid user name")
 }
 
-func TestLoggerSerrorf(t *testing.T) {
+func TestLogger_Serrorf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Serrorf("hello %s", "bob")
 }
 
-func TestLoggerSinfo(t *testing.T) {
+func TestLogger_Sinfo(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Sinfo("invalid user name")
 }
 
-func TestLoggerSinfof(t *testing.T) {
+func TestLogger_Sinfof(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Sinfof("hello %s", "bob")
 }
 
-func TestLoggerDebug(t *testing.T) {
+func TestLogger_Debug(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Debug(fmt.Errorf("invalid user name"))
 }
 
-func TestLoggerDebugf(t *testing.T) {
+func TestLogger_Debugf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Debugf(fmt.Errorf("invalid user name"), "hello %s", "bob")
 }
@@ -104,12 +104,12 @@ func TestLogger_err(t *testing.T) {
 	logger.err(e)
 }
 
-func TestLoggerError(t *testing.T) {
+func TestLogger_Error(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Error(fmt.Errorf("invalid user name"))
 }
 
-func TestLoggerErrorf(t *testing.T) {
+func TestLogger_Errorf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Errorf(fmt.Errorf("invalid user name"), "hello %s", "bob")
 }
@@ -121,12 +121,12 @@ func TestLogger_fatal(t *testing.T) {
 	logger.fatal(e)
 }
 
-func TestLoggerFatal(t *testing.T) {
+func TestLogger_Fatal(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Fatal(nil)
 }
 
-func TestLoggerFatalf(t *testing.T) {
+func TestLogger_Fatalf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Fatalf(nil, "hello %s", "bob")
 }
@@ -140,12 +140,12 @@ func TestLogger_info(t *testing.T) {
 	logger.info(e)
 }
 
-func TestLoggerInfo(t *testing.T) {
+func TestLogger_Info(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Info(fmt.Errorf("invalid user name"))
 }
 
-func TestLoggerInfof(t *testing.T) {
+func TestLogger_Infof(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Infof(fmt.Errorf("invalid user name"), "hello %s", "bob")
 }
@@ -159,12 +159,12 @@ func TestLogger_warn(t *testing.T) {
 	logger.warn(e)
 }
 
-func TestLoggerWarn(t *testing.T) {
+func TestLogger_Warn(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Warn(fmt.Errorf("invalid user name"))
 }
 
-func TestLoggerWarnf(t *testing.T) {
+func TestLogger_Warnf(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.Warnf(fmt.Errorf("invalid user name"), "hello %s", "bob")
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -41,7 +41,7 @@ func TestLogger_debug(t *testing.T) {
 	logger.debug(nil)
 	logger.debug(fmt.Errorf("hello"))
 	logger.debug(New(nil, "bar"))
-	var e *Error
+	var e *base
 	logger.debug(e)
 }
 
@@ -100,7 +100,7 @@ func TestLogger_err(t *testing.T) {
 	logger.err(nil)
 	logger.err(fmt.Errorf("hello"))
 	logger.err(New(nil, "bar"))
-	var e *Error
+	var e *base
 	logger.err(e)
 }
 
@@ -117,7 +117,7 @@ func TestLogger_Errorf(t *testing.T) {
 func TestLogger_fatal(t *testing.T) {
 	logger := NewLogger(nil)
 	logger.fatal(nil)
-	var e *Error
+	var e *base
 	logger.fatal(e)
 }
 
@@ -136,7 +136,7 @@ func TestLogger_info(t *testing.T) {
 	logger.info(nil)
 	logger.info(fmt.Errorf("hello"))
 	logger.info(New(nil, "bar"))
-	var e *Error
+	var e *base
 	logger.info(e)
 }
 
@@ -155,7 +155,7 @@ func TestLogger_warn(t *testing.T) {
 	logger.warn(nil)
 	logger.warn(fmt.Errorf("hello"))
 	logger.warn(New(nil, "bar"))
-	var e *Error
+	var e *base
 	logger.warn(e)
 }
 


### PR DESCRIPTION
BREAKING CHANGE

* Rename `Error` to `base` so `Error` isn't published
* Remove some methods
  * Error.CheckField
  * Error.GetField
  * Error.HasField
  * Error.HasMsg
  * Error.Fields
  * Error.Msgs

---

Improve tests with table driven test.